### PR TITLE
Webpack dev server

### DIFF
--- a/FantasyCritic.Web/ClientApp/index.ejs
+++ b/FantasyCritic.Web/ClientApp/index.ejs
@@ -12,6 +12,7 @@
     <title></title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui">
     <meta name="description" content="">
+    <link rel="stylesheet" href="dist/vendor.css" />
 
 <body>
     <div id="vue-app"></div>

--- a/FantasyCritic.Web/ClientApp/index.ejs
+++ b/FantasyCritic.Web/ClientApp/index.ejs
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <% for (var chunk in htmlWebpackPlugin.files.css) { %>
+    <link rel="preload" href="<%= htmlWebpackPlugin.files.css[chunk] %>" as="style">
+    <% } %>
+    <% for (var chunk in htmlWebpackPlugin.files.chunks) { %>
+    <link rel="preload" href="<%= htmlWebpackPlugin.files.chunks[chunk].entry %>" as="script">
+    <% } %>
+    <meta charset="utf-8">
+    <title></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimal-ui">
+    <meta name="description" content="">
+
+<body>
+    <div id="vue-app"></div>
+    <script src="dist/vendor.js"></script>
+    <script src="dist/main.js"></script>
+</body>
+
+</html>

--- a/FantasyCritic.Web/package-lock.json
+++ b/FantasyCritic.Web/package-lock.json
@@ -2654,6 +2654,16 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2782,6 +2792,23 @@
           "requires": {
             "is-descriptor": "^0.1.0"
           }
+        }
+      }
+    },
+    "clean-css": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+      "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
+      "dev": true,
+      "requires": {
+        "source-map": "~0.6.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -3751,6 +3778,15 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "dom-converter": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.2.0.tgz",
+      "integrity": "sha512-gd3ypIPfOMr9h5jIKq8E3sHOTCjeirnl0WK5ZdS1AW0Odt0b1PaWaHdJ4Qk4klv+YB9aJBS7mESXjFoDQPu6DA==",
+      "dev": true,
+      "requires": {
+        "utila": "~0.4"
       }
     },
     "dom-serializer": {
@@ -5888,6 +5924,70 @@
       "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
       "dev": true
     },
+    "html-minifier": {
+      "version": "3.5.21",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.21.tgz",
+      "integrity": "sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==",
+      "dev": true,
+      "requires": {
+        "camel-case": "3.0.x",
+        "clean-css": "4.2.x",
+        "commander": "2.17.x",
+        "he": "1.2.x",
+        "param-case": "2.1.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "3.4.x"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true
+        }
+      }
+    },
+    "html-webpack-plugin": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
+      "dev": true,
+      "requires": {
+        "html-minifier": "^3.2.3",
+        "loader-utils": "^0.2.16",
+        "lodash": "^4.17.3",
+        "pretty-error": "^2.0.2",
+        "tapable": "^1.0.0",
+        "toposort": "^1.0.0",
+        "util.promisify": "1.0.0"
+      },
+      "dependencies": {
+        "big.js": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
+          "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+          "dev": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+          "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+          "dev": true
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "dev": true,
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
+          }
+        }
+      }
+    },
     "htmlparser2": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
@@ -6739,6 +6839,12 @@
         "signal-exit": "^3.0.0"
       }
     },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
     "lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -7271,6 +7377,15 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
+    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -7790,6 +7905,15 @@
         "cyclist": "~0.2.2",
         "inherits": "^2.0.3",
         "readable-stream": "^2.1.5"
+      }
+    },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
       }
     },
     "parent-module": {
@@ -8589,6 +8713,16 @@
       "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
       "dev": true
     },
+    "pretty-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",
+      "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
+      "dev": true,
+      "requires": {
+        "renderkid": "^2.0.1",
+        "utila": "~0.4"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -8959,11 +9093,54 @@
         }
       }
     },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
+    },
+    "renderkid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.3.tgz",
+      "integrity": "sha512-z8CLQp7EZBPCwCnncgf9C4XAi3WR0dv+uWu/PjIyhhAb5d6IJ/QZqlHFprHeKT+59//V6BNUsLbvN8+2LarxGA==",
+      "dev": true,
+      "requires": {
+        "css-select": "^1.1.0",
+        "dom-converter": "^0.2",
+        "htmlparser2": "^3.3.0",
+        "strip-ansi": "^3.0.0",
+        "utila": "^0.4.0"
+      },
+      "dependencies": {
+        "css-select": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+          "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+          "dev": true,
+          "requires": {
+            "boolbase": "~1.0.0",
+            "css-what": "2.1",
+            "domutils": "1.5.1",
+            "nth-check": "~1.0.1"
+          }
+        },
+        "domutils": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+          "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "0",
+            "domelementtype": "1"
+          }
+        }
+      }
     },
     "repeat-element": {
       "version": "1.1.3",
@@ -10391,6 +10568,12 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "toposort": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-1.0.7.tgz",
+      "integrity": "sha1-LmhELZ9k7HILjMieZEOsbKqVACk=",
+      "dev": true
+    },
     "tough-cookie": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
@@ -10477,6 +10660,30 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
+    },
+    "uglify-js": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
+      "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
+      "dev": true,
+      "requires": {
+        "commander": "~2.19.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -10606,6 +10813,12 @@
       "integrity": "sha512-kXpym8nmDmlCBr7nKdIx8P2jNBa+pBpIUFRnKJ4dr8htyYGJFokkr2ZvERRtUN+9SY+JqXouNgUPtv6JQva/2Q==",
       "dev": true
     },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -10706,6 +10919,12 @@
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"
       }
+    },
+    "utila": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
+      "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/FantasyCritic.Web/package.json
+++ b/FantasyCritic.Web/package.json
@@ -11,6 +11,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "start": "webpack-dev-server --open",
     "dev": "cross-env ASPNETCORE_ENVIRONMENT=Development NODE_ENV=development dotnet run",
     "build": "npm run build-vendor:prod && npm run build:prod",
     "build:prod": "cross-env NODE_ENV=production webpack --progress --hide-modules",

--- a/FantasyCritic.Web/package.json
+++ b/FantasyCritic.Web/package.json
@@ -82,6 +82,7 @@
     "event-source-polyfill": "^1.0.7",
     "file-loader": "^4.1.0",
     "font-awesome": "^4.7.0",
+    "html-webpack-plugin": "^3.2.0",
     "jquery": "^3.4.1",
     "mini-css-extract-plugin": "^0.8.0",
     "node-sass": "^4.12.0",

--- a/FantasyCritic.Web/package.json
+++ b/FantasyCritic.Web/package.json
@@ -11,7 +11,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "start": "webpack-dev-server --open",
+    "client": "cross-env NODE_ENV=development webpack-dev-server --config webpack.config.client.js --open",
     "dev": "cross-env ASPNETCORE_ENVIRONMENT=Development NODE_ENV=development dotnet run",
     "build": "npm run build-vendor:prod && npm run build:prod",
     "build:prod": "cross-env NODE_ENV=production webpack --progress --hide-modules",

--- a/FantasyCritic.Web/webpack.config.client.js
+++ b/FantasyCritic.Web/webpack.config.client.js
@@ -76,7 +76,7 @@ module.exports = () => {
             '[resourcePath]') // Point sourcemap entries to the original file locations on disk
       }),
       new HtmlWebpackPlugin({
-        template: './ClientApp/index.ejs',
+        template: './ClientApp/index.ejs', // convert index ejs template to html
         minify: { collapseWhitespace: true }
       })
     ]

--- a/FantasyCritic.Web/webpack.config.client.js
+++ b/FantasyCritic.Web/webpack.config.client.js
@@ -1,0 +1,86 @@
+const path = require('path')
+const webpack = require('webpack')
+const bundleOutputDir = './wwwroot/dist'
+const VueLoaderPlugin = require('vue-loader/lib/plugin')
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = () => {
+  console.log('Building for \x1b[33m%s\x1b[0m development')
+
+  let configObject = {
+    mode: 'development',
+    stats: { modules: false },
+    entry: { 'main': './ClientApp/boot-app.js' },
+    devtool: 'eval-source-map',
+    devServer: {
+      contentBase: path.join(__dirname, 'wwwroot'),
+      host: 'localhost',
+      publicPath: '/',
+      historyApiFallback: true,
+      open: true,
+      hot: true,
+      inline: true,
+      proxy: {
+        // Route the api calls to the acutal site
+        '/api/**': {
+          target: 'https://www.fantasycritic.games',
+          secure: false,
+          changeOrigin: true
+        }
+      }
+    },
+    resolve: {
+      extensions: ['.js', '.vue'],
+      alias: {
+        'vue$': 'vue/dist/vue',
+        'components': path.resolve(__dirname, './ClientApp/components'),
+        'views': path.resolve(__dirname, './ClientApp/views'),
+        'utils': path.resolve(__dirname, './ClientApp/utils'),
+        'api': path.resolve(__dirname, './ClientApp/store/api')
+      }
+    },
+    output: {
+      path: path.join(__dirname, bundleOutputDir),
+      filename: '[name].js',
+      publicPath: '/dist/'
+    },
+    module: {
+      rules: [
+        {
+          test: /\.vue$/,
+          include: /ClientApp/,
+          loader: 'vue-loader'
+        },
+        { test: /\.js$/, include: /ClientApp/, use: 'babel-loader' },
+        { test: /\.(png|jpg|jpeg|gif|svg)$/, use: 'url-loader?limit=25000' },
+        {
+          test: /\.css$/,
+          use: ['style-loader', 'css-loader']
+        },
+        {
+          test: /\.scss$/,
+          use: ['style-loader', 'css-loader', 'sass-loader']
+        }
+      ]
+    },
+    plugins: [
+      new VueLoaderPlugin(),
+      new webpack.DllReferencePlugin({
+        context: __dirname,
+        manifest: require('./wwwroot/dist/vendor-manifest.json')
+      }),
+      new webpack.SourceMapDevToolPlugin({
+        filename: '[file].map', // Remove this line if you prefer inline source maps
+        moduleFilenameTemplate:
+          path.relative(bundleOutputDir,
+            '[resourcePath]') // Point sourcemap entries to the original file locations on disk
+      }),
+      new HtmlWebpackPlugin({
+        template: './ClientApp/index.ejs',
+        minify: { collapseWhitespace: true }
+      })
+    ]
+  };
+
+  return [configObject];
+}

--- a/FantasyCritic.Web/webpack.config.js
+++ b/FantasyCritic.Web/webpack.config.js
@@ -4,7 +4,8 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
 const bundleOutputDir = './wwwroot/dist'
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
-var CompressionPlugin = require('compression-webpack-plugin');
+const CompressionPlugin = require('compression-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = () => {
   console.log('Building for \x1b[33m%s\x1b[0m', process.env.NODE_ENV)
@@ -21,6 +22,12 @@ module.exports = () => {
     entry: { 'main': './ClientApp/boot-app.js' },
     devServer: {
       contentBase: path.join(__dirname, 'wwwroot'),
+      host: 'localhost',
+      publicPath: '/',
+      historyApiFallback: true,
+      open: true,
+      hot: true,
+      inline: true,
       proxy: {
         // Route the api calls to the acutal site
         '/api/**': {
@@ -104,6 +111,14 @@ module.exports = () => {
 
   if (isDevBuild) {
     configObject.devtool = "eval-source-map";
+  }
+
+  if (true) {
+    configObject.plugins.push(
+      new HtmlWebpackPlugin({
+        template: './ClientApp/index.ejs',
+        minify: { collapseWhitespace: true }
+    }))
   }
 
   return [configObject];

--- a/FantasyCritic.Web/webpack.config.js
+++ b/FantasyCritic.Web/webpack.config.js
@@ -4,8 +4,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
 const bundleOutputDir = './wwwroot/dist'
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
-const CompressionPlugin = require('compression-webpack-plugin');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+var CompressionPlugin = require('compression-webpack-plugin');
 
 module.exports = () => {
   console.log('Building for \x1b[33m%s\x1b[0m', process.env.NODE_ENV)
@@ -20,23 +19,6 @@ module.exports = () => {
     mode: (isDevBuild ? 'development' : 'production'),
     stats: { modules: false },
     entry: { 'main': './ClientApp/boot-app.js' },
-    devServer: {
-      contentBase: path.join(__dirname, 'wwwroot'),
-      host: 'localhost',
-      publicPath: '/',
-      historyApiFallback: true,
-      open: true,
-      hot: true,
-      inline: true,
-      proxy: {
-        // Route the api calls to the acutal site
-        '/api/**': {
-          target: 'https://www.fantasycritic.games',
-          secure: false,
-          changeOrigin: true
-        }
-      }
-    },
     resolve: {
       extensions: ['.js', '.vue'],
       alias: isDevBuild
@@ -111,14 +93,6 @@ module.exports = () => {
 
   if (isDevBuild) {
     configObject.devtool = "eval-source-map";
-  }
-
-  if (true) {
-    configObject.plugins.push(
-      new HtmlWebpackPlugin({
-        template: './ClientApp/index.ejs',
-        minify: { collapseWhitespace: true }
-    }))
   }
 
   return [configObject];

--- a/FantasyCritic.Web/webpack.config.js
+++ b/FantasyCritic.Web/webpack.config.js
@@ -20,7 +20,15 @@ module.exports = () => {
     stats: { modules: false },
     entry: { 'main': './ClientApp/boot-app.js' },
     devServer: {
-      contentBase: path.join(__dirname, 'wwwroot')
+      contentBase: path.join(__dirname, 'wwwroot'),
+      proxy: {
+        // Route the api calls to the acutal site
+        '/api/**': {
+          target: 'https://www.fantasycritic.games',
+          secure: false,
+          changeOrigin: true
+        }
+      }
     },
     resolve: {
       extensions: ['.js', '.vue'],

--- a/FantasyCritic.Web/webpack.config.js
+++ b/FantasyCritic.Web/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = () => {
   console.log('Building for \x1b[33m%s\x1b[0m', process.env.NODE_ENV)
 
   const isDevBuild = !(process.env.NODE_ENV && process.env.NODE_ENV === 'production')
-  
+
   const extractCSS = new MiniCssExtractPlugin({
     filename: 'style.css'
   })
@@ -19,6 +19,9 @@ module.exports = () => {
     mode: (isDevBuild ? 'development' : 'production'),
     stats: { modules: false },
     entry: { 'main': './ClientApp/boot-app.js' },
+    devServer: {
+      contentBase: path.join(__dirname, 'wwwroot')
+    },
     resolve: {
       extensions: ['.js', '.vue'],
       alias: isDevBuild

--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ Fantasy Critic is like fantasy football...but for video games! You and several f
           based on scores from <a href="https://opencritic.com/">opencritic.com</a>.
 
 You can see the site at  <a href="https://www.fantasycritic.games/">fantasycritic.games</a>
+
+### ClientApp
+ClientApp is the root directory for the front-end UI. In it contains a Vue.js client application. See the official [Vue.js documentation](https://vuejs.org/) for more
+information. The project is configured to start its own instance of the client app in the background when the ASP.NET Core app starts in development mode. The client
+app can also be run via webpack dev server, instead of the ASP.NET core app. Note, when using the webpack dev server, the client app will point the the 
+[official website](https://www.fantasycritic.games/), instead of the local ASP.NET core app.
+```sh
+> npm run client
+```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can see the site at  <a href="https://www.fantasycritic.games/">fantasycriti
 ### ClientApp
 ClientApp is the root directory for the front-end UI. In it contains a Vue.js client application. See the official [Vue.js documentation](https://vuejs.org/) for more
 information. The project is configured to start its own instance of the client app in the background when the ASP.NET Core app starts in development mode. The client
-app can also be run via webpack dev server, instead of the ASP.NET core app. Note, when using the webpack dev server, the client app will point the the 
+app can also be run via webpack dev server, instead of the ASP.NET core app. Note, when using the webpack dev server, the client app will point the 
 [official website](https://www.fantasycritic.games/), instead of the local ASP.NET core app.
 ```sh
 > npm run client

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ You can see the site at  <a href="https://www.fantasycritic.games/">fantasycriti
 ### ClientApp
 ClientApp is the root directory for the front-end UI. In it contains a Vue.js client application. See the official [Vue.js documentation](https://vuejs.org/) for more
 information. The project is configured to start its own instance of the client app in the background when the ASP.NET Core app starts in development mode. The client
-app can also be run via webpack dev server, instead of the ASP.NET core app. Note, when using the webpack dev server, the client app will point the 
+app can also be run via webpack dev server, instead of the ASP.NET core app. Note, when using the webpack dev server, the client app will point to the 
 [official website](https://www.fantasycritic.games/), instead of the local ASP.NET core app.
 ```sh
 > npm run client


### PR DESCRIPTION
This PR is intended to allow developers to the serve front-end without the need of running the ASP.NET core app (which currently is not completely setup on github).

A new webpack config file was created to defined the webpack dev server properties. You can use this confirmation by using the `npm run client` command. The config uses a proxy to point to the actual site. HRM (hot module replace), is also setup in this config. Changes to the client app, should be replaced on the page, but any changes to the ASP.NET core app, will not (after all its not running). 

HtmlWebpackPlugin , was added as a dev dependency. This plugin allows the rendering of the `index.ejs` file. Since, the ASP.NET core app is not running, this plugin is needed to provide an index page and serve the client app bundle. 
