### PR TITLE
Add description to bidding form

### DIFF
--- a/FantasyCritic.Web/ClientApp/components/modules/modals/bidGameForm.vue
+++ b/FantasyCritic.Web/ClientApp/components/modules/modals/bidGameForm.vue
@@ -3,6 +3,11 @@
     <div v-if="errorInfo" class="alert alert-danger" role="alert">
       {{errorInfo}}
     </div>
+    <p>
+      You can use this form to place a bid on a game.
+      <br />
+      Bids are processed on Monday Nights. See the FAQ for more info.
+    </p>
     <form method="post" class="form-horizontal" role="form" v-on:submit.prevent="searchGame">
       <label for="bidGameName" class="control-label">Game Name</label>
       <div class="input-group game-search-input">


### PR DESCRIPTION
Currently, the start of the bidding process shows no description above the form. It'd be helpful to at least have the time when bids are processed shown at the start of the process. That is currently how the drop game form functions:

![image](https://user-images.githubusercontent.com/5701044/73614238-e7041d80-45c2-11ea-9af5-bd6235a7d9d4.png)

This PR just adds a small description above the form.