### PR TITLE
Add IIS configuration for static file caching

### DIFF
--- a/FantasyCritic.Web/ClientApp/public/css/web.config
+++ b/FantasyCritic.Web/ClientApp/public/css/web.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <staticContent>
+      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="365:00:00:00" />
+    </staticContent>
+  </system.webServer>
+</configuration>

--- a/FantasyCritic.Web/ClientApp/public/js/web.config
+++ b/FantasyCritic.Web/ClientApp/public/js/web.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+  <system.webServer>
+    <staticContent>
+      <clientCache cacheControlMode="UseMaxAge" cacheControlMaxAge="365:00:00:00" />
+    </staticContent>
+  </system.webServer>
+</configuration>


### PR DESCRIPTION
I noticed that the site is being served on IIS and there's no `Cache-Control` or `Expires` headers for even the totally static files. Depending on how you deploy and configure IIS, this is an example of a config that should have IIS serve the files in the `css` and `js` folders as immutable (cached for one year). This is safe because Webpack/Babel includes a contents hash in the name so that the name will be different if the file changes at all ("cache-busting").

This should save 2 MB Javascript/300 KB CSS on every app load after the first!