### PR TITLE
Vue cli client proxy

### DIFF
--- a/FantasyCritic.Web/ClientApp/package.json
+++ b/FantasyCritic.Web/ClientApp/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "client": "vue-cli-service serve --mode client",
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint"

--- a/FantasyCritic.Web/ClientApp/vue.config.js
+++ b/FantasyCritic.Web/ClientApp/vue.config.js
@@ -5,10 +5,13 @@ let config = {
 if (process.env.NODE_ENV === "client") {
   config = {
     ...config,
+    configureWebpack: {
+      mode: "development",
+    },
     devServer: {
       proxy: {
         // Route the api calls to the acutal site
-        "/api/**": {
+        "/api/*": {
           target: "https://www.fantasycritic.games",
           secure: false,
           changeOrigin: true,

--- a/FantasyCritic.Web/ClientApp/vue.config.js
+++ b/FantasyCritic.Web/ClientApp/vue.config.js
@@ -1,3 +1,21 @@
-module.exports = {
-  lintOnSave: false
+let config = {
+  lintOnSave: false,
+};
+
+if (process.env.NODE_ENV === "client") {
+  config = {
+    ...config,
+    devServer: {
+      proxy: {
+        // Route the api calls to the acutal site
+        "/api/**": {
+          target: "https://www.fantasycritic.games",
+          secure: false,
+          changeOrigin: true,
+        },
+      },
+    },
+  };
 }
+
+module.exports = config;


### PR DESCRIPTION
Adding back (from the old webpack config), the proxy server config. If you set NODE_ENV to "client" mode, the client app will be pointing to the official website site. Useful if you don't have the backend setup but want to work on front end development. 