### PR TITLE
Change wording of Master Game Request reasoning

### DIFF
--- a/src/FantasyCritic.Web/ClientApp/src/views/masterGameRequest.vue
+++ b/src/FantasyCritic.Web/ClientApp/src/views/masterGameRequest.vue
@@ -18,10 +18,10 @@
 
         <label>Please describe why you are requesting this game:</label>
         <b-form-checkbox v-model="wantToPickup">
-          <span class="checkbox-label">I'm interested in drafting or bidding on this game.</span>
+          <span class="checkbox-label">I want to draft or bid on this game.</span>
         </b-form-checkbox>
         <b-form-checkbox v-model="nearCertainInterested">
-          <span class="checkbox-label">Someone else will likely be interested in drafting or bidding on this game.</span>
+          <span class="checkbox-label">I'm certain someone else wants to draft or bid on this game.</span>
         </b-form-checkbox>
         <br />
         <div class="alert alert-info">

--- a/src/FantasyCritic.Web/ClientApp/src/views/masterGameRequest.vue
+++ b/src/FantasyCritic.Web/ClientApp/src/views/masterGameRequest.vue
@@ -18,10 +18,10 @@
 
         <label>Please describe why you are requesting this game:</label>
         <b-form-checkbox v-model="wantToPickup">
-          <span class="checkbox-label">I want to draft or bid on this game immediately.</span>
+          <span class="checkbox-label">I'm interested in drafting or bidding on this game.</span>
         </b-form-checkbox>
         <b-form-checkbox v-model="nearCertainInterested">
-          <span class="checkbox-label">I'm essentially certain someone else wants to draft or bid on this game very soon.</span>
+          <span class="checkbox-label">Someone else will likely be interested in drafting or bidding on this game.</span>
         </b-form-checkbox>
         <br />
         <div class="alert alert-info">


### PR DESCRIPTION
I found that the reasoning options in the Master Game Request page to be unnecessarily confusing. It's my understanding that these options are worded the way they are so that users are less inclined to submit obscure games that nobody would ever want to draft or bid on. This PR is meant to make those options easier to understand at a glance while retaining the intention of the original text.

`I want to draft or bid on this game immediately.` ➔ `I'm interested in drafting or bidding on this game.`
Whether or not you want to bid on the game "immediately" isn't a necessary specification and makes the purpose of the option more confusing. Replacing "want" with "interested" gives the text a less hostile feeling.

`I'm essentially certain someone else wants to draft or bid on this game very soon.` ➔ `Someone else will likely be interested in drafting or bidding on this game.`
The purpose of this option is specifying if this game request is for you or somebody else. Keeping the wording very similar in both options and only changing the necessary aspects allows the choices to be more easily understood. This change makes the second option easily comparable to the first.
