### PR TITLE
Remove redundant verified includes

### DIFF
--- a/src/FantasyCritic.Test/FantasyCritic.Test.csproj
+++ b/src/FantasyCritic.Test/FantasyCritic.Test.csproj
@@ -26,28 +26,4 @@
     <ProjectReference Include="..\FantasyCritic.SharedSerialization\FantasyCritic.SharedSerialization.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="ActionProcessingTests\BaseActionProcessingTests.SuccessDropsTest.verified.txt">
-      <DependentUpon>BaseActionProcessingTests.cs</DependentUpon>
-    </None>
-    <None Update="ActionProcessingTests\BaseActionProcessingTests.SuccessBidsTest.verified.txt">
-      <DependentUpon>BaseActionProcessingTests.cs</DependentUpon>
-    </None>
-    <None Update="ActionProcessingTests\BaseActionProcessingTests.RemovedPublisherGamesTest.verified.txt">
-      <DependentUpon>BaseActionProcessingTests.cs</DependentUpon>
-    </None>
-    <None Update="ActionProcessingTests\BaseActionProcessingTests.LeagueActionsTest.verified.txt">
-      <DependentUpon>BaseActionProcessingTests.cs</DependentUpon>
-    </None>
-    <None Update="ActionProcessingTests\BaseActionProcessingTests.FailedDropsTest.verified.txt">
-      <DependentUpon>BaseActionProcessingTests.cs</DependentUpon>
-    </None>
-    <None Update="ActionProcessingTests\BaseActionProcessingTests.FailedBidsTest.verified.txt">
-      <DependentUpon>BaseActionProcessingTests.cs</DependentUpon>
-    </None>
-    <None Update="ActionProcessingTests\BaseActionProcessingTests.AddedPublisherGamesTest.verified.txt">
-      <DependentUpon>BaseActionProcessingTests.cs</DependentUpon>
-    </None>
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
These occur due to a bug in VS where it incorrectly duplicates dynamic includes when you copy/rename a test file.