### PR TITLE
Add flex-wrap property to search-tags

### DIFF
--- a/src/FantasyCritic.Web/ClientApp/src/components/modals/bidCounterPickForm.vue
+++ b/src/FantasyCritic.Web/ClientApp/src/components/modals/bidCounterPickForm.vue
@@ -159,6 +159,7 @@ export default {
 
 .search-tags {
   display: flex;
+  flex-wrap: wrap;
   padding: 5px;
   background: rgba(50, 50, 50, 0.7);
   border-radius: 5px;

--- a/src/FantasyCritic.Web/ClientApp/src/css/site.css
+++ b/src/FantasyCritic.Web/ClientApp/src/css/site.css
@@ -259,6 +259,7 @@ img.critic-royale-nav {
 
 .search-tags {
   display: flex;
+  flex-wrap: wrap;
   padding: 5px;
   background: rgba(50, 50, 50, 0.7);
   border-radius: 5px;


### PR DESCRIPTION
Added the flex-wrap property to the search-tags classes in both the bidCounterPickForm.vue and site.css files. This ensures that the tags wrap as expected in the search element, improving the web application's overall UI/UX.

![localhost_5001_league_3590cb15-6a87-439f-bc4a-91d5b5fe2ca8_2024 (1)](https://github.com/SteveF92/FantasyCritic/assets/10599339/b0b25a67-887e-4289-9ff5-8f2a753376b9)
