### PR TITLE
Add private until accepted trade system

### DIFF
--- a/src/FantasyCritic.DatabaseUpdater/Scripts/Sequential/2026-06-20_000_privateUntilAcceptedTradingSystem.sql
+++ b/src/FantasyCritic.DatabaseUpdater/Scripts/Sequential/2026-06-20_000_privateUntilAcceptedTradingSystem.sql
@@ -1,0 +1,2 @@
+INSERT IGNORE INTO `tbl_settings_tradingsystem` (`TradingSystem`) VALUES
+    ('PrivateUntilAccepted');

--- a/src/FantasyCritic.IntegrationTests/Tests/League/Actions/TradePrivacyTests.cs
+++ b/src/FantasyCritic.IntegrationTests/Tests/League/Actions/TradePrivacyTests.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using FantasyCritic.ApiClient;
+using FantasyCritic.IntegrationTests.Helpers;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+
+namespace FantasyCritic.IntegrationTests.Tests.League.Actions;
+
+[TestFixture]
+public class TradePrivacyTests : IntegrationTestBase
+{
+    private LeagueFixture _privateLeague = null!;
+    private LeagueFixture _standardLeague = null!;
+
+    private Guid _privateAcceptedTradeID;
+    private Guid _privateRescindedTradeID;
+    private Guid _standardProposedTradeID;
+
+    private IReadOnlyList<Guid> _privateProposerProposalActiveTrades = null!;
+    private IReadOnlyList<Guid> _privateCounterPartyProposalActiveTrades = null!;
+    private IReadOnlyList<Guid> _privateNonInvolvedProposalActiveTrades = null!;
+    private IReadOnlyList<Guid> _privateManagerProposalActiveTrades = null!;
+    private IReadOnlyList<Guid> _privateNonInvolvedAcceptedActiveTrades = null!;
+    private IReadOnlyList<Guid> _privateManagerAcceptedActiveTrades = null!;
+    private IReadOnlyList<Guid> _privateHistoryTradeIDs = null!;
+    private IReadOnlyList<Guid> _privateExportTradeIDs = null!;
+    private IReadOnlyList<Guid> _standardNonInvolvedProposalActiveTrades = null!;
+    private IReadOnlyList<Guid> _standardManagerProposalActiveTrades = null!;
+
+    private int? _privateProposalVoteStatusCode;
+    private int? _privateProposalManagerRejectStatusCode;
+
+    [OneTimeSetUp]
+    public async Task SetUpTradePrivacyLeagues()
+    {
+        _privateLeague = await BuildDraftedLeagueAsync("PrivateUntilAccepted");
+        await SetUpPrivateUntilAcceptedTradesAsync();
+
+        _standardLeague = await BuildDraftedLeagueAsync("Standard");
+        await SetUpStandardTradeAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task TearDownTradePrivacyLeagues()
+    {
+        if (_privateLeague != null)
+        {
+            await _privateLeague.DisposeAsync();
+        }
+
+        if (_standardLeague != null)
+        {
+            await _standardLeague.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public void PrivateProposal_IsVisibleOnlyToProposerAndCounterparty()
+    {
+        Assert.That(_privateProposerProposalActiveTrades, Does.Contain(_privateAcceptedTradeID));
+        Assert.That(_privateCounterPartyProposalActiveTrades, Does.Contain(_privateAcceptedTradeID));
+        Assert.That(_privateNonInvolvedProposalActiveTrades, Does.Not.Contain(_privateAcceptedTradeID));
+        Assert.That(_privateManagerProposalActiveTrades, Does.Not.Contain(_privateAcceptedTradeID));
+    }
+
+    [Test]
+    public void PrivateProposal_BlocksNonInvolvedDirectVoteAndManagerReject()
+    {
+        Assert.That(_privateProposalVoteStatusCode, Is.EqualTo(403));
+        Assert.That(_privateProposalManagerRejectStatusCode, Is.EqualTo(403));
+    }
+
+    [Test]
+    public void PrivateAcceptedTrade_BecomesVisibleToLeagueAndManager()
+    {
+        Assert.That(_privateNonInvolvedAcceptedActiveTrades, Does.Contain(_privateAcceptedTradeID));
+        Assert.That(_privateManagerAcceptedActiveTrades, Does.Contain(_privateAcceptedTradeID));
+    }
+
+    [Test]
+    public void PrivateNeverAcceptedTrades_AreExcludedFromHistoryAndExport()
+    {
+        Assert.That(_privateHistoryTradeIDs, Does.Contain(_privateAcceptedTradeID));
+        Assert.That(_privateHistoryTradeIDs, Does.Not.Contain(_privateRescindedTradeID));
+
+        Assert.That(_privateExportTradeIDs, Does.Contain(_privateAcceptedTradeID));
+        Assert.That(_privateExportTradeIDs, Does.Not.Contain(_privateRescindedTradeID));
+    }
+
+    [Test]
+    public void StandardProposal_RemainsVisibleToNonInvolvedMembersAndManager()
+    {
+        Assert.That(_standardNonInvolvedProposalActiveTrades, Does.Contain(_standardProposedTradeID));
+        Assert.That(_standardManagerProposalActiveTrades, Does.Contain(_standardProposedTradeID));
+    }
+
+    private async Task<LeagueFixture> BuildDraftedLeagueAsync(string tradingSystem)
+    {
+        var scenario = new LeagueScenario
+        {
+            Name = $"TradePrivacy-{tradingSystem}",
+            PlayerCount = 4,
+            StandardGames = 2,
+            GamesToDraft = 2,
+            CounterPicks = 0,
+            CounterPicksToDraft = 0,
+            DraftSystem = "Flexible",
+            PickupSystem = "SemiPublicBiddingSecretCounterPicks",
+            ScoringSystem = "LinearPositive",
+            TradingSystem = tradingSystem,
+            TiebreakSystem = "LowestProjectedPoints",
+            ReleaseSystem = "MustBeReleased",
+            IneligibleGameSystem = "DroppableAsWillNotRelease",
+            UnrestrictedReleaseStatusDroppableGames = 0,
+            WillNotReleaseDroppableGames = 0,
+            WillReleaseDroppableGames = 0,
+            DropOnlyDraftGames = true,
+            GrantSuperDrops = false,
+            CounterPicksBlockDrops = true,
+            AllowMoveIntoIneligible = false,
+            MinimumBidAmount = 0,
+        };
+
+        var league = await LeagueFixtureBuilder.CreateAndStartDraftAsync(Factory, scenario, NewUser);
+        await league.DraftToCompletionAsync();
+        return league;
+    }
+
+    private async Task SetUpPrivateUntilAcceptedTradesAsync()
+    {
+        var proposer = _privateLeague.Publishers[1];
+        var counterParty = _privateLeague.Publishers[2];
+        var nonInvolvedPlayer = _privateLeague.Publishers[3];
+        var manager = _privateLeague.Manager;
+
+        _privateAcceptedTradeID = await ProposeOneForOneTradeAsync(_privateLeague, proposer, counterParty, "private accepted trade");
+
+        _privateProposerProposalActiveTrades = await GetActiveTradeIDsAsync(proposer.Session, _privateLeague);
+        _privateCounterPartyProposalActiveTrades = await GetActiveTradeIDsAsync(counterParty.Session, _privateLeague);
+        _privateNonInvolvedProposalActiveTrades = await GetActiveTradeIDsAsync(nonInvolvedPlayer.Session, _privateLeague);
+        _privateManagerProposalActiveTrades = await GetActiveTradeIDsAsync(manager, _privateLeague);
+
+        var privateTradeRequest = BuildBasicTradeRequest(_privateLeague, _privateAcceptedTradeID);
+        _privateProposalVoteStatusCode = await CaptureApiStatusCodeAsync(() => nonInvolvedPlayer.Session.League.VoteOnTradeAsync(
+            new TradeVoteRequest
+            {
+                LeagueID = _privateLeague.LeagueID,
+                Year = _privateLeague.Year,
+                TradeID = _privateAcceptedTradeID,
+                Approved = true,
+                Comment = "not allowed yet",
+            }));
+        _privateProposalManagerRejectStatusCode = await CaptureApiStatusCodeAsync(() => manager.LeagueManager.RejectTradeAsync(privateTradeRequest));
+
+        await counterParty.Session.League.AcceptTradeAsync(privateTradeRequest);
+
+        _privateNonInvolvedAcceptedActiveTrades = await GetActiveTradeIDsAsync(nonInvolvedPlayer.Session, _privateLeague);
+        _privateManagerAcceptedActiveTrades = await GetActiveTradeIDsAsync(manager, _privateLeague);
+
+        await nonInvolvedPlayer.Session.League.VoteOnTradeAsync(new TradeVoteRequest
+        {
+            LeagueID = _privateLeague.LeagueID,
+            Year = _privateLeague.Year,
+            TradeID = _privateAcceptedTradeID,
+            Approved = true,
+            Comment = "visible after acceptance",
+        });
+        await manager.LeagueManager.RejectTradeAsync(privateTradeRequest);
+
+        _privateRescindedTradeID = await ProposeOneForOneTradeAsync(_privateLeague, nonInvolvedPlayer, proposer, "private rescinded trade");
+        await nonInvolvedPlayer.Session.League.RescindTradeAsync(BuildBasicTradeRequest(_privateLeague, _privateRescindedTradeID));
+
+        _privateHistoryTradeIDs = await GetTradeHistoryIDsAsync(manager, _privateLeague);
+        _privateExportTradeIDs = await GetConsolidatedExportTradeIDsAsync(manager, _privateLeague);
+    }
+
+    private async Task SetUpStandardTradeAsync()
+    {
+        var proposer = _standardLeague.Publishers[1];
+        var counterParty = _standardLeague.Publishers[2];
+        var nonInvolvedPlayer = _standardLeague.Publishers[3];
+
+        _standardProposedTradeID = await ProposeOneForOneTradeAsync(_standardLeague, proposer, counterParty, "standard proposed trade");
+        _standardNonInvolvedProposalActiveTrades = await GetActiveTradeIDsAsync(nonInvolvedPlayer.Session, _standardLeague);
+        _standardManagerProposalActiveTrades = await GetActiveTradeIDsAsync(_standardLeague.Manager, _standardLeague);
+    }
+
+    private static async Task<Guid> ProposeOneForOneTradeAsync(LeagueFixture league, TestPublisher proposer, TestPublisher counterParty, string message)
+    {
+        var leagueYear = await proposer.Session.League.GetLeagueYearAsync(league.LeagueID, league.Year, null);
+        var proposerGame = GetTradeableGame(leagueYear, proposer.PublisherID);
+        var counterPartyGame = GetTradeableGame(leagueYear, counterParty.PublisherID);
+
+        await proposer.Session.League.ProposeTradeAsync(new ProposeTradeRequest
+        {
+            ProposerPublisherID = proposer.PublisherID,
+            CounterPartyPublisherID = counterParty.PublisherID,
+            ProposerPublisherGameIDs = new List<Guid> { proposerGame.PublisherGameID },
+            CounterPartyPublisherGameIDs = new List<Guid> { counterPartyGame.PublisherGameID },
+            ProposerBudgetSendAmount = 0,
+            CounterPartyBudgetSendAmount = 0,
+            Message = message,
+        });
+
+        var updatedLeagueYear = await proposer.Session.League.GetLeagueYearAsync(league.LeagueID, league.Year, null);
+        return updatedLeagueYear.ActiveTrades.Single(x => x.Message == message).TradeID;
+    }
+
+    private static PublisherGameViewModel GetTradeableGame(LeagueYearViewModel leagueYear, Guid publisherID)
+    {
+        var publisher = leagueYear.Publishers.Single(x => x.PublisherID == publisherID);
+        return publisher.Games.First(x => !x.CounterPick && x.MasterGame is not null);
+    }
+
+    private static async Task<IReadOnlyList<Guid>> GetActiveTradeIDsAsync(ApiSession session, LeagueFixture league)
+    {
+        var leagueYear = await session.League.GetLeagueYearAsync(league.LeagueID, league.Year, null);
+        return leagueYear.ActiveTrades.Select(x => x.TradeID).ToList();
+    }
+
+    private static async Task<IReadOnlyList<Guid>> GetTradeHistoryIDsAsync(ApiSession session, LeagueFixture league)
+    {
+        var history = await session.GetAndDeserializeAsync<JArray>($"/api/League/TradeHistory?leagueID={league.LeagueID}&year={league.Year}");
+        return history.Select(x => Guid.Parse(x.Value<string>("tradeID")!)).ToList();
+    }
+
+    private static async Task<IReadOnlyList<Guid>> GetConsolidatedExportTradeIDsAsync(ApiSession session, LeagueFixture league)
+    {
+        using var response = await session.GetAsync($"/api/League/DownloadConsolidatedLeagueYearData?leagueID={league.LeagueID}&year={league.Year}");
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        var trades = (JArray?)JObject.Parse(body)["trades"] ?? new JArray();
+        return trades.Select(x => Guid.Parse(x.Value<string>("tradeID")!)).ToList();
+    }
+
+    private static BasicTradeRequest BuildBasicTradeRequest(LeagueFixture league, Guid tradeID) =>
+        new()
+        {
+            LeagueID = league.LeagueID,
+            Year = league.Year,
+            TradeID = tradeID,
+        };
+
+    private static async Task<int?> CaptureApiStatusCodeAsync(Func<Task> action)
+    {
+        try
+        {
+            await action();
+            return null;
+        }
+        catch (ApiException ex)
+        {
+            return ex.StatusCode;
+        }
+    }
+}

--- a/src/FantasyCritic.Lib/Domain/Trades/Trade.cs
+++ b/src/FantasyCritic.Lib/Domain/Trades/Trade.cs
@@ -52,6 +52,52 @@ public class Trade
         };
     }
 
+    public bool UserIsInvolved(Guid userID)
+    {
+        return Proposer.User.Id == userID || CounterParty.User.Id == userID;
+    }
+
+    public bool IsPrivateProposal()
+    {
+        return LeagueYear.Options.TradingSystem.Equals(TradingSystem.PrivateUntilAccepted) &&
+               Status.Equals(TradeStatus.Proposed);
+    }
+
+    public bool IsVisibleToUser(Guid? userID)
+    {
+        if (!IsPrivateProposal())
+        {
+            return true;
+        }
+
+        return userID.HasValue && UserIsInvolved(userID.Value);
+    }
+
+    public bool IsVisibleInLeagueHistory()
+    {
+        if (Status.IsActive)
+        {
+            return false;
+        }
+
+        if (!LeagueYear.Options.TradingSystem.Equals(TradingSystem.PrivateUntilAccepted))
+        {
+            return true;
+        }
+
+        return AcceptedTimestamp.HasValue;
+    }
+
+    public bool IsVisibleInConsolidatedExport()
+    {
+        if (!LeagueYear.Options.TradingSystem.Equals(TradingSystem.PrivateUntilAccepted))
+        {
+            return true;
+        }
+
+        return AcceptedTimestamp.HasValue;
+    }
+
     public Instant? GetExpirationTime()
     {
         if (!Status.IsActive)

--- a/src/FantasyCritic.Lib/Enums/TradingSystem.cs
+++ b/src/FantasyCritic.Lib/Enums/TradingSystem.cs
@@ -6,6 +6,7 @@ public class TradingSystem : TypeSafeEnum<TradingSystem>
     // Define values here.
     public static readonly TradingSystem NoTrades = new TradingSystem("NoTrades", "No Trades");
     public static readonly TradingSystem Standard = new TradingSystem("Standard", "Standard");
+    public static readonly TradingSystem PrivateUntilAccepted = new TradingSystem("PrivateUntilAccepted", "Private Until Accepted");
 
     // Constructor is private: values are defined within this class only!
     private TradingSystem(string value, string readableName)

--- a/src/FantasyCritic.Lib/Services/TradeService.cs
+++ b/src/FantasyCritic.Lib/Services/TradeService.cs
@@ -104,7 +104,7 @@ public class TradeService
         }
 
         await _fantasyCriticRepo.CreateTrade(trade);
-        await _discordPushService.SendTradeMessage(trade);
+        await SendPublicTradeMessageIfVisible(trade);
 
         return Result.Success();
     }
@@ -129,7 +129,7 @@ public class TradeService
 
         var now = _clock.GetCurrentInstant();
         var rescindedTrade = await _fantasyCriticRepo.EditTradeStatus(trade, TradeStatus.Rescinded, null, now);
-        await _discordPushService.SendTradeMessage(rescindedTrade);
+        await SendPublicTradeMessageIfVisible(rescindedTrade);
         return Result.Success();
     }
 
@@ -142,7 +142,7 @@ public class TradeService
 
         var now = _clock.GetCurrentInstant();
         var updatedTrade = await _fantasyCriticRepo.EditTradeStatus(trade, TradeStatus.Accepted, now, null);
-        await _discordPushService.SendTradeMessage(updatedTrade);
+        await SendPublicTradeMessageIfVisible(updatedTrade);
         return Result.Success();
     }
 
@@ -155,7 +155,7 @@ public class TradeService
 
         var now = _clock.GetCurrentInstant();
         var rejectedTrade = await _fantasyCriticRepo.EditTradeStatus(trade, TradeStatus.RejectedByCounterParty, null, now);
-        await _discordPushService.SendTradeMessage(rejectedTrade);
+        await SendPublicTradeMessageIfVisible(rejectedTrade);
         return Result.Success();
     }
 
@@ -168,7 +168,7 @@ public class TradeService
 
         var now = _clock.GetCurrentInstant();
         var rejectedTrade = await _fantasyCriticRepo.EditTradeStatus(trade, TradeStatus.RejectedByManager, null, now);
-        await _discordPushService.SendTradeMessage(rejectedTrade);
+        await SendPublicTradeMessageIfVisible(rejectedTrade);
         return Result.Success();
     }
 
@@ -220,7 +220,23 @@ public class TradeService
 
         var executedTrade = new ExecutedTrade(trade, completionTime, newPublisherGamesResult.Value);
         var finalizedTrade = await _fantasyCriticRepo.ExecuteTrade(executedTrade);
-        await _discordPushService.SendTradeMessage(finalizedTrade);
+        await SendPublicTradeMessageIfVisible(finalizedTrade);
         return Result.Success();
+    }
+
+    private Task SendPublicTradeMessageIfVisible(Trade trade)
+    {
+        if (ShouldSuppressPublicTradeMessage(trade))
+        {
+            return Task.CompletedTask;
+        }
+
+        return _discordPushService.SendTradeMessage(trade);
+    }
+
+    private static bool ShouldSuppressPublicTradeMessage(Trade trade)
+    {
+        return trade.LeagueYear.Options.TradingSystem.Equals(TradingSystem.PrivateUntilAccepted) &&
+               !trade.AcceptedTimestamp.HasValue;
     }
 }

--- a/src/FantasyCritic.Web/ClientApp/src/views/faq.vue
+++ b/src/FantasyCritic.Web/ClientApp/src/views/faq.vue
@@ -490,7 +490,7 @@
     <collapseCard>
       <template #header>How do trades work?</template>
       <template #body>
-        Your league can chose whether or not to allow trades. If allowed, trades become available after the draft is over. The following rules apply:
+        Your league can choose whether or not to allow trades. If allowed, trades become available after the draft is over. The following rules apply:
         <ul>
           <li>Trades are always between 2 players.</li>
           <li>Each side can include any number of games as well as any budget ($) they have available.</li>
@@ -508,6 +508,23 @@
         </ul>
         Note that the "votes" by the league members are not "votes" in the democracy sense. League managers should weigh them when deciding what to do with the trade, but ultimately, they have full
         control.
+      </template>
+    </collapseCard>
+    <collapseCard>
+      <template #header>What are the trade system options?</template>
+      <template #body>
+        <p>League managers choose a trade system when creating or editing a league year.</p>
+        <ul>
+          <li><strong>No Trades:</strong> Trades are disabled for the league year.</li>
+          <li>
+            <strong>Standard:</strong> Trade proposals are visible to the league as soon as they are proposed. Other league members can see active proposals, and public trade notifications can be sent
+            to Discord if the league has Discord integration enabled.
+          </li>
+          <li>
+            <strong>Private Until Accepted:</strong> New proposals are visible only to the two players involved. If the counterparty accepts the trade, it becomes visible to the rest of the league for
+            the normal review and voting process. Proposals that are rescinded, rejected, or expire before being accepted stay private and do not appear in trade history.
+          </li>
+        </ul>
       </template>
     </collapseCard>
     <collapseCard>

--- a/src/FantasyCritic.Web/Controllers/API/LeagueController.cs
+++ b/src/FantasyCritic.Web/Controllers/API/LeagueController.cs
@@ -1832,6 +1832,11 @@ public class LeagueController : BaseLeagueController
             return BadRequest();
         }
 
+        if (trade.IsPrivateProposal())
+        {
+            return StatusCode(403);
+        }
+
         var validUserIDs = leagueYear.Publishers.Select(x => x.User.Id).Except(new List<Guid>()
             {trade.Proposer.User.Id, trade.CounterParty.User.Id}).ToHashSet();
         bool userIsInLeagueButNotInTrade = validUserIDs.Contains(currentUser.Id);
@@ -1869,6 +1874,11 @@ public class LeagueController : BaseLeagueController
         if (trade is null)
         {
             return BadRequest();
+        }
+
+        if (trade.IsPrivateProposal())
+        {
+            return StatusCode(403);
         }
 
         var validUserIDs = leagueYear.Publishers.Select(x => x.User.Id).Except(new List<Guid>()
@@ -1912,7 +1922,7 @@ public class LeagueController : BaseLeagueController
 
         var currentDate = _clock.GetToday();
         var trades = await _tradeService.GetTradesForLeague(leagueYear);
-        var inactiveTrades = trades.Where(x => !x.Status.IsActive);
+        var inactiveTrades = trades.Where(x => x.IsVisibleInLeagueHistory());
         var viewModels = inactiveTrades.Select(x => new TradeViewModel(x, currentDate));
         return viewModels.ToList();
     }

--- a/src/FantasyCritic.Web/Controllers/API/LeagueManagerController.cs
+++ b/src/FantasyCritic.Web/Controllers/API/LeagueManagerController.cs
@@ -1211,11 +1211,18 @@ public class LeagueManagerController : BaseLeagueController
         {
             return leagueYearRecord.FailedResult;
         }
+        var validResult = leagueYearRecord.ValidResult!;
+        var currentUser = validResult.CurrentUser!;
 
         var trade = await _tradeService.GetTrade(request.TradeID);
         if (trade is null)
         {
             return BadRequest();
+        }
+
+        if (trade.IsPrivateProposal() && !trade.UserIsInvolved(currentUser.Id))
+        {
+            return StatusCode(403);
         }
 
         Result result = await _tradeService.RejectTradeByManager(trade);

--- a/src/FantasyCritic.Web/Models/Responses/ConsolidatedLeagueDataViewModel.cs
+++ b/src/FantasyCritic.Web/Models/Responses/ConsolidatedLeagueDataViewModel.cs
@@ -102,7 +102,11 @@ public class ConsolidatedLeagueYearViewModel
 
         ManagerMessages = domain.ManagerMessages.Select(x => new ManagerMessageViewModel(x, false)).OrderBy(x => x.Timestamp).ToList();
 
-        Trades = domain.Trades.Select(x => new TradeViewModel(x, currentDate)).OrderByDescending(x => x.ProposedTimestamp).ToList();
+        Trades = domain.Trades
+            .Where(x => x.IsVisibleInConsolidatedExport())
+            .Select(x => new TradeViewModel(x, currentDate))
+            .OrderByDescending(x => x.ProposedTimestamp)
+            .ToList();
 
         SpecialAuctions = domain.SpecialAuctions.Select(x => new SpecialAuctionViewModel(x, currentInstant)).ToList();
 

--- a/src/FantasyCritic.Web/Models/Responses/LeagueYearViewModel.cs
+++ b/src/FantasyCritic.Web/Models/Responses/LeagueYearViewModel.cs
@@ -117,7 +117,10 @@ public class LeagueYearViewModel
             PublicBiddingGames = new PublicBiddingSetViewModel(supplementalData.PublicBiddingGames, currentDate);
         }
 
-        ActiveTrades = supplementalData.ActiveTrades.Select(x => new TradeViewModel(x, currentDate)).ToList();
+        ActiveTrades = supplementalData.ActiveTrades
+            .Where(x => x.IsVisibleToUser(accessingUser?.Id))
+            .Select(x => new TradeViewModel(x, currentDate))
+            .ToList();
         ActiveSpecialAuctions = supplementalData.ActiveSpecialAuctions.Select(x => new SpecialAuctionViewModel(x, currentInstant)).ToList();
         GameNews = gameNews;
         AllPublishersForUser = supplementalData.AllPublishersForUser.Select(p => new LeaguePublisherViewModel(p.PublisherID, p.PublisherName, p.LeagueID, p.LeagueName, p.Year)).ToList();


### PR DESCRIPTION
As discussed in #80, this adds a new optional trade system: Private Until Accepted.

In leagues using this option, new trade proposals are visible only to the proposer and counterparty. If the counterparty accepts, the trade becomes visible to the rest of the league for the normal review and voting process.

Standard trade behavior remains unchanged.

Also added faq copy to explain the difference between the different trading systems. 

Implementation notes:
- Adds TradingSystem.PrivateUntilAccepted and a data-only settings-table migration.
- Filters private proposed trades out of active trade views for non-involved users and managers.
- Blocks non-involved vote/manager-reject API calls while a private proposal is still unaccepted.
- Hides never-accepted private proposals from trade history and consolidated league export data.
- Suppresses public Discord trade announcements for private proposal-stage events. Public Discord trade announcements still happen after acceptance.
- No Discord DM behavior or counteroffer behavior is included.

Tested:
- dotnet test src/FantasyCritic.IntegrationTests/FantasyCritic.IntegrationTests.csproj --no-build --filter TradePrivacyTests
- dotnet build src/FantasyCritic.Web/FantasyCritic.Web.csproj
- npm run build in src/FantasyCritic.Web/ClientApp
- Manual local browser testing with Private Until Accepted and Standard leagues