### PR TITLE
Add a notes field to watchlist games.

### DIFF
--- a/src/FantasyCritic.DatabaseUpdater/Scripts/Sequential/2026-09-06_000_watchlistNotes.sql
+++ b/src/FantasyCritic.DatabaseUpdater/Scripts/Sequential/2026-09-06_000_watchlistNotes.sql
@@ -1,0 +1,2 @@
+ALTER TABLE tbl_league_publisherqueue
+    ADD COLUMN Notes varchar(1000) NULL AFTER `Ranking`;

--- a/src/FantasyCritic.IntegrationTests/Tests/League/Actions/WatchlistNotesTests.cs
+++ b/src/FantasyCritic.IntegrationTests/Tests/League/Actions/WatchlistNotesTests.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FantasyCritic.ApiClient;
+using FantasyCritic.IntegrationTests.Helpers;
+using NUnit.Framework;
+
+namespace FantasyCritic.IntegrationTests.Tests.League.Actions;
+
+/// <summary>
+/// Tests the per-game notes a publisher can keep on their watchlist (queued games).
+/// </summary>
+[TestFixture]
+public class WatchlistNotesTests : IntegrationTestBase
+{
+    private LeagueFixture _league = null!;
+    private TestPublisher _publisher = null!;
+    private Guid _queuedMasterGameID;
+
+    [OneTimeSetUp]
+    public async Task SetUpWatchlist()
+    {
+        _league = await LeagueFixtureBuilder.CreateLeagueWithMembersAsync(
+            Factory, LeagueScenarios.Standard, NewUser);
+        _publisher = _league.Publishers[0];
+
+        var available = await _publisher.Session.League.TopAvailableGamesAsync(
+            _league.Year, _league.LeagueID, _publisher.PublisherID, null);
+        _queuedMasterGameID = available.First(g => g.IsAvailable && !g.IsReleased).MasterGame.MasterGameID;
+
+        var queueResult = await _publisher.Session.League.AddGameToQueueAsync(new AddGameToQueueRequest
+        {
+            PublisherID = _publisher.PublisherID,
+            MasterGameID = _queuedMasterGameID,
+        });
+
+        Assert.That(queueResult.Success, Is.True,
+            $"Failed to queue game: {string.Join("; ", queueResult.Errors ?? [])}");
+    }
+
+    [OneTimeTearDown]
+    public async Task TearDownSessions() => await _league.DisposeAsync();
+
+    private async Task<QueuedGameViewModel> GetQueuedGameAsync()
+    {
+        var leagueYear = await _publisher.Session.League.GetLeagueYearAsync(_league.LeagueID, _league.Year, null);
+        Assert.That(leagueYear.PrivatePublisherData, Is.Not.Null,
+            "The publisher's own request should include their private publisher data.");
+        return leagueYear.PrivatePublisherData!.QueuedGames
+            .Single(x => x.MasterGame.MasterGameID == _queuedMasterGameID);
+    }
+
+    [Test, Order(1)]
+    public async Task QueuedGame_WhenFirstAdded_HasNoNotes()
+    {
+        var queuedGame = await GetQueuedGameAsync();
+        Assert.That(queuedGame.Notes, Is.Null);
+    }
+
+    [Test, Order(2)]
+    public async Task SetQueuedGameNotes_WithNotes_PersistsThem()
+    {
+        await _publisher.Session.League.SetQueuedGameNotesAsync(new SetQueuedGameNotesRequest
+        {
+            PublisherID = _publisher.PublisherID,
+            MasterGameID = _queuedMasterGameID,
+            Notes = "Same studio as their last game, which reviewed well.",
+        });
+
+        var queuedGame = await GetQueuedGameAsync();
+        Assert.That(queuedGame.Notes, Is.EqualTo("Same studio as their last game, which reviewed well."));
+    }
+
+    [Test, Order(3)]
+    public async Task SetQueuedGameNotes_WithWhitespaceOnly_ClearsNotes()
+    {
+        await _publisher.Session.League.SetQueuedGameNotesAsync(new SetQueuedGameNotesRequest
+        {
+            PublisherID = _publisher.PublisherID,
+            MasterGameID = _queuedMasterGameID,
+            Notes = "   ",
+        });
+
+        var queuedGame = await GetQueuedGameAsync();
+        Assert.That(queuedGame.Notes, Is.Null);
+    }
+
+    [Test, Order(4)]
+    public async Task SetQueuedGameNotes_TooLong_Returns400()
+    {
+        ApiException? ex = null;
+        try
+        {
+            await _publisher.Session.League.SetQueuedGameNotesAsync(new SetQueuedGameNotesRequest
+            {
+                PublisherID = _publisher.PublisherID,
+                MasterGameID = _queuedMasterGameID,
+                Notes = new string('a', 1001),
+            });
+        }
+        catch (ApiException caught)
+        {
+            ex = caught;
+        }
+
+        Assert.That(ex, Is.Not.Null, "Expected ApiException for notes over the maximum length.");
+        Assert.That(ex!.StatusCode, Is.EqualTo(400));
+    }
+
+    [Test, Order(5)]
+    public async Task SetQueuedGameNotes_ForGameNotOnWatchlist_Returns400()
+    {
+        ApiException? ex = null;
+        try
+        {
+            await _publisher.Session.League.SetQueuedGameNotesAsync(new SetQueuedGameNotesRequest
+            {
+                PublisherID = _publisher.PublisherID,
+                MasterGameID = Guid.NewGuid(),
+                Notes = "Notes for a game that isn't queued.",
+            });
+        }
+        catch (ApiException caught)
+        {
+            ex = caught;
+        }
+
+        Assert.That(ex, Is.Not.Null, "Expected ApiException for a game that is not on the watchlist.");
+        Assert.That(ex!.StatusCode, Is.EqualTo(400));
+    }
+}

--- a/src/FantasyCritic.Lib/Domain/QueuedGame.cs
+++ b/src/FantasyCritic.Lib/Domain/QueuedGame.cs
@@ -2,16 +2,20 @@ namespace FantasyCritic.Lib.Domain;
 
 public class QueuedGame
 {
-    public QueuedGame(Publisher publisher, MasterGame masterGame, int rank)
+    public const int MaximumNotesLength = 1000;
+
+    public QueuedGame(Publisher publisher, MasterGame masterGame, int rank, string? notes)
     {
         Publisher = publisher;
         MasterGame = masterGame;
         Rank = rank;
+        Notes = notes;
     }
 
     public Publisher Publisher { get; }
     public MasterGame MasterGame { get; }
     public int Rank { get; }
+    public string? Notes { get; }
 
     public override string ToString()
     {

--- a/src/FantasyCritic.Lib/Interfaces/IFantasyCriticRepo.cs
+++ b/src/FantasyCritic.Lib/Interfaces/IFantasyCriticRepo.cs
@@ -103,6 +103,7 @@ public interface IFantasyCriticRepo
     Task QueueGame(QueuedGame queuedGame);
     Task RemoveQueuedGame(QueuedGame queuedGame);
     Task SetQueueRankings(IReadOnlyList<KeyValuePair<QueuedGame, int>> queueRanks);
+    Task SetQueuedGameNotes(QueuedGame queuedGame, string? notes);
 
     Task AddLeagueAction(LeagueAction action);
     Task AddLeagueManagerAction(LeagueManagerAction action);

--- a/src/FantasyCritic.Lib/Services/GameAcquisitionService.cs
+++ b/src/FantasyCritic.Lib/Services/GameAcquisitionService.cs
@@ -174,7 +174,7 @@ public class GameAcquisitionService
         }
 
         var nextRank = queuedGames.Count + 1;
-        QueuedGame queuedGame = new QueuedGame(publisher, masterGame, nextRank);
+        QueuedGame queuedGame = new QueuedGame(publisher, masterGame, nextRank, null);
         await _fantasyCriticRepo.QueueGame(queuedGame);
 
         return claimResult;

--- a/src/FantasyCritic.Lib/Services/PublisherService.cs
+++ b/src/FantasyCritic.Lib/Services/PublisherService.cs
@@ -177,6 +177,23 @@ public class PublisherService
         return Result.Success();
     }
 
+    public async Task<Result> SetQueuedGameNotes(QueuedGame queuedGame, string? notes)
+    {
+        var trimmedNotes = notes?.Trim();
+        if (string.IsNullOrEmpty(trimmedNotes))
+        {
+            trimmedNotes = null;
+        }
+
+        if (trimmedNotes is not null && trimmedNotes.Length > QueuedGame.MaximumNotesLength)
+        {
+            return Result.Failure($"Notes cannot be longer than {QueuedGame.MaximumNotesLength} characters.");
+        }
+
+        await _fantasyCriticRepo.SetQueuedGameNotes(queuedGame, trimmedNotes);
+        return Result.Success();
+    }
+
     public async Task<IReadOnlyList<MinimalPublisher>> GetMinimalPublishersForUser(Guid? userID, int year)
     {
         if (!userID.HasValue)

--- a/src/FantasyCritic.MySQL/Entities/QueuedGameEntity.cs
+++ b/src/FantasyCritic.MySQL/Entities/QueuedGameEntity.cs
@@ -12,14 +12,16 @@ public class QueuedGameEntity
         PublisherID = domain.Publisher.PublisherID;
         MasterGameID = domain.MasterGame.MasterGameID;
         Ranking = domain.Rank;
+        Notes = domain.Notes;
     }
 
     public Guid PublisherID { get; set; }
     public Guid MasterGameID { get; set; }
     public int Ranking { get; set; }
+    public string? Notes { get; set; }
 
     public QueuedGame ToDomain(Publisher publisher, MasterGame masterGame)
     {
-        return new QueuedGame(publisher, masterGame, Ranking);
+        return new QueuedGame(publisher, masterGame, Ranking, Notes);
     }
 }

--- a/src/FantasyCritic.MySQL/MySQLFantasyCriticRepo.cs
+++ b/src/FantasyCritic.MySQL/MySQLFantasyCriticRepo.cs
@@ -847,9 +847,21 @@ public class MySQLFantasyCriticRepo : IFantasyCriticRepo
     public async Task QueueGame(QueuedGame queuedGame)
     {
         var entity = new QueuedGameEntity(queuedGame);
-        const string sql = "insert into tbl_league_publisherqueue(PublisherID,MasterGameID,`Ranking`) VALUES (@PublisherID,@MasterGameID,@Ranking);";
+        const string sql = "insert into tbl_league_publisherqueue(PublisherID,MasterGameID,`Ranking`,Notes) VALUES (@PublisherID,@MasterGameID,@Ranking,@Notes);";
         await using var connection = new MySqlConnection(_connectionString);
         await connection.ExecuteAsync(sql, entity);
+    }
+
+    public async Task SetQueuedGameNotes(QueuedGame queuedGame, string? notes)
+    {
+        const string sql = "update tbl_league_publisherqueue set Notes = @notes where PublisherID = @publisherID AND MasterGameID = @masterGameID;";
+        await using var connection = new MySqlConnection(_connectionString);
+        await connection.ExecuteAsync(sql, new
+        {
+            notes,
+            publisherID = queuedGame.Publisher.PublisherID,
+            masterGameID = queuedGame.MasterGame.MasterGameID
+        });
     }
 
     public async Task RemoveQueuedGame(QueuedGame queuedGame)

--- a/src/FantasyCritic.Web/ClientApp/src/components/modals/gameQueueForm.vue
+++ b/src/FantasyCritic.Web/ClientApp/src/components/modals/gameQueueForm.vue
@@ -78,6 +78,7 @@
           <th scope="col" class="game-column">Release Date</th>
           <th scope="col">Hype Factor</th>
           <th scope="col">Ranking</th>
+          <th scope="col" class="notes-column">Notes</th>
           <th scope="col">Status</th>
           <th scope="col"></th>
         </tr>
@@ -92,6 +93,22 @@
           </td>
           <td>{{ queuedGame.masterGame.dateAdjustedHypeFactor | score(1) }}</td>
           <td>{{ queuedGame.rank }}</td>
+          <td class="notes-cell">
+            <div v-if="editingNotesFor === queuedGame.masterGame.masterGameID">
+              <b-form-textarea v-model="notesInEdit" rows="3" :maxlength="maximumNotesLength"></b-form-textarea>
+              <div class="notes-edit-buttons">
+                <b-button variant="secondary" size="sm" @click="cancelEditingNotes">Cancel</b-button>
+                <b-button variant="primary" size="sm" @click="saveNotes(queuedGame)">Save</b-button>
+              </div>
+            </div>
+            <div v-else class="notes-display">
+              <span v-if="queuedGame.notes" class="notes-text">{{ queuedGame.notes }}</span>
+              <span v-else class="no-notes">No notes</span>
+              <b-button variant="secondary" size="sm" title="Edit notes" @click="startEditingNotes(queuedGame)">
+                <font-awesome-icon icon="pen" />
+              </b-button>
+            </div>
+          </td>
           <td>
             <statusBadge :possible-master-game="queuedGame"></statusBadge>
           </td>
@@ -137,7 +154,10 @@ export default {
       showingOtherLeagueWatchlist: false,
       isBusy: false,
       selectedSlotIndex: 0,
-      selectedOtherPublisher: null
+      selectedOtherPublisher: null,
+      editingNotesFor: null,
+      notesInEdit: '',
+      maximumNotesLength: 1000
     };
   },
   computed: {
@@ -253,6 +273,26 @@ export default {
       await this.notifyAction('Watchlist reordered.');
       this.initializeDesiredRankings();
     },
+    startEditingNotes(queuedGame) {
+      this.editingNotesFor = queuedGame.masterGame.masterGameID;
+      this.notesInEdit = queuedGame.notes ?? '';
+    },
+    cancelEditingNotes() {
+      this.editingNotesFor = null;
+      this.notesInEdit = '';
+    },
+    async saveNotes(queuedGame) {
+      const model = {
+        publisherID: this.userPublisher.publisherID,
+        masterGameID: queuedGame.masterGame.masterGameID,
+        notes: this.notesInEdit
+      };
+
+      await axios.post('/api/league/SetQueuedGameNotes', model);
+      this.cancelEditingNotes();
+      await this.notifyAction('Watchlist notes saved.');
+      this.initializeDesiredRankings();
+    },
     async removeQueuedGame(game) {
       const model = {
         publisherID: this.userPublisher.publisherID,
@@ -264,6 +304,7 @@ export default {
       this.initializeDesiredRankings();
     },
     clearAllData() {
+      this.cancelEditingNotes();
       this.clearQueueData();
       this.searchGameName = null;
       this.possibleMasterGames = [];
@@ -308,5 +349,36 @@ export default {
 .publisher-name {
   font-style: italic;
   font-size: 12px;
+}
+
+.notes-column {
+  min-width: 200px;
+}
+
+.notes-cell {
+  vertical-align: top;
+}
+
+.notes-display {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 5px;
+}
+
+.notes-text {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.no-notes {
+  font-style: italic;
+}
+
+.notes-edit-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 5px;
+  margin-top: 5px;
 }
 </style>

--- a/src/FantasyCritic.Web/Controllers/API/LeagueController.cs
+++ b/src/FantasyCritic.Web/Controllers/API/LeagueController.cs
@@ -1520,6 +1520,7 @@ public class LeagueController : BaseLeagueController
     }
 
     [HttpPost]
+    [ProducesResponseType<QueueResultViewModel>(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status403Forbidden)]
@@ -1608,6 +1609,37 @@ public class LeagueController : BaseLeagueController
         }
 
         Result result = await _publisherService.SetQueueRankings(queueRanks);
+        if (result.IsFailure)
+        {
+            return BadRequest(result.Error);
+        }
+
+        return Ok();
+    }
+
+    [HttpPost]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public async Task<IActionResult> SetQueuedGameNotes([FromBody] SetQueuedGameNotesRequest request)
+    {
+        var publisherRecord = await GetExistingLeagueYearAndPublisher(request.PublisherID, ActionProcessingModeBehavior.Allow, RequiredRelationship.BePublisher, RequiredYearStatus.AnyYearNotFinished);
+        if (publisherRecord.FailedResult is not null)
+        {
+            return publisherRecord.FailedResult;
+        }
+        var validResult = publisherRecord.ValidResult!;
+        var publisher = validResult.Publisher;
+
+        var queuedGames = await _publisherService.GetQueuedGames(publisher);
+        var thisQueuedGame = queuedGames.SingleOrDefault(x => x.MasterGame.MasterGameID == request.MasterGameID);
+        if (thisQueuedGame is null)
+        {
+            return BadRequest();
+        }
+
+        Result result = await _publisherService.SetQueuedGameNotes(thisQueuedGame, request.Notes);
         if (result.IsFailure)
         {
             return BadRequest(result.Error);

--- a/src/FantasyCritic.Web/Models/Requests/League/SetQueuedGameNotesRequest.cs
+++ b/src/FantasyCritic.Web/Models/Requests/League/SetQueuedGameNotesRequest.cs
@@ -1,0 +1,3 @@
+namespace FantasyCritic.Web.Models.Requests.League;
+
+public record SetQueuedGameNotesRequest(Guid PublisherID, Guid MasterGameID, string? Notes);

--- a/src/FantasyCritic.Web/Models/Responses/QueuedGameViewModel.cs
+++ b/src/FantasyCritic.Web/Models/Responses/QueuedGameViewModel.cs
@@ -6,12 +6,14 @@ public class QueuedGameViewModel
     {
         MasterGame = new MasterGameYearViewModel(masterGameYear, currentDate);
         Rank = queuedGame.Rank;
+        Notes = queuedGame.Notes;
         Taken = taken;
         AlreadyOwned = alreadyOwned;
     }
 
     public MasterGameYearViewModel MasterGame { get; }
     public int Rank { get; }
+    public string? Notes { get; }
     public bool Taken { get; }
     public bool AlreadyOwned { get; }
     public bool IsAvailable => !Taken && !AlreadyOwned;


### PR DESCRIPTION
Resolves #83. Players can now keep per-game research notes on their watchlist, so the reasoning behind adding a game is still there weeks later when roster decisions come up.